### PR TITLE
upgrade name conflict

### DIFF
--- a/Sources/Response.swift
+++ b/Sources/Response.swift
@@ -23,46 +23,46 @@
 // SOFTWARE.
 
 extension Response {
-    public typealias Upgrade = (Request, Stream) throws -> Void
+    public typealias OnUpgrade = (Request, Stream) throws -> Void
 
-    public var upgrade: Upgrade? {
+    public var onUpgrade: OnUpgrade? {
         get {
-            return storage["response-connection-upgrade"] as? Upgrade
+            return storage["response-connection-upgrade"] as? OnUpgrade
         }
 
-        set(upgrade) {
-            storage["response-connection-upgrade"] = upgrade
+        set(onUpgrade) {
+            storage["response-connection-upgrade"] = onUpgrade
         }
     }
 }
 
 extension Response {
-    public init(status: Status = .ok, headers: Headers = [:], body: Stream, upgrade: Upgrade?) {
+    public init(status: Status = .ok, headers: Headers = [:], body: Stream, onUpgrade: OnUpgrade?) {
         self.init(
             status: status,
             headers: headers,
             body: body
         )
 
-        self.upgrade = upgrade
+        self.onUpgrade = onUpgrade
     }
 
-    public init(status: Status = .ok, headers: Headers = [:], body: Data = Data(), upgrade: Upgrade?) {
+    public init(status: Status = .ok, headers: Headers = [:], body: Data = Data(), onUpgrade: OnUpgrade?) {
         self.init(
             status: status,
             headers: headers,
             body: body
         )
 
-        self.upgrade = upgrade
+        self.onUpgrade = onUpgrade
     }
 
-    public init(status: Status = .ok, headers: Headers = [:], body: DataConvertible, upgrade: Upgrade? = nil) {
+    public init(status: Status = .ok, headers: Headers = [:], body: DataConvertible, onUpgrade: OnUpgrade? = nil) {
         self.init(
             status: status,
             headers: headers,
             body: body.data,
-            upgrade: upgrade
+            onUpgrade: onUpgrade
         )
     }
 }


### PR DESCRIPTION
## Problem

Message and Request both uses “upgrade”

https://github.com/Zewo/HTTP/blob/master/Sources/Message.swift#L82

https://github.com/Zewo/HTTP/blob/master/Sources/Request.swift#L28
## Reason

S4 Defines Request is following protocol but upgrade for two different reason.

https://github.com/open-swift/S4/blob/master/Sources/Request.swift#L1

```
public struct Request: Message {
```
## Fix

request.upgrade changes to
request.onUpgrade since this is callback function
