### PR TITLE
'upgrade' name conflict 

### DIFF
--- a/Sources/Request.swift
+++ b/Sources/Request.swift
@@ -23,21 +23,21 @@
 // SOFTWARE.
 
 extension Request {
-    public typealias Upgrade = (Response, Stream) throws -> Void
+    public typealias DidUpgrade = (Response, Stream) throws -> Void
 
-    public var upgrade: Upgrade? {
+    public var didUpgrade: DidUpgrade? {
         get {
-            return storage["request-upgrade"] as? Upgrade
+            return storage["request-upgrade"] as? DidUpgrade
         }
 
-        set(upgrade) {
-            storage["request-upgrade"] = upgrade
+        set(didUpgrade) {
+            storage["request-upgrade"] = didUpgrade
         }
     }
 }
 
 extension Request {
-    public init(method: Method = .get, uri: URI = URI(path: "/"), headers: Headers = [:], body: Stream, upgrade: Upgrade?) {
+    public init(method: Method = .get, uri: URI = URI(path: "/"), headers: Headers = [:], body: Stream, didUpgrade: DidUpgrade?) {
         self.init(
             method: method,
             uri: uri,
@@ -45,10 +45,10 @@ extension Request {
             body: body
         )
 
-        self.upgrade = upgrade
+        self.didUpgrade = didUpgrade
     }
 
-    public init(method: Method = .get, uri: URI = URI(path: "/"), headers: Headers = [:], body: Data = Data(), upgrade: Upgrade?) {
+    public init(method: Method = .get, uri: URI = URI(path: "/"), headers: Headers = [:], body: Data = Data(), didUpgrade: DidUpgrade?) {
         self.init(
             method: method,
             uri: uri,
@@ -56,46 +56,46 @@ extension Request {
             body: body
         )
 
-        self.upgrade = upgrade
+        self.didUpgrade = didUpgrade
     }
 
-    public init(method: Method = .get, uri: URI = URI(path: "/"), headers: Headers = [:], body: DataConvertible, upgrade: Upgrade? = nil) {
+    public init(method: Method = .get, uri: URI = URI(path: "/"), headers: Headers = [:], body: DataConvertible, didUpgrade: DidUpgrade? = nil) {
         self.init(
             method: method,
             uri: uri,
             headers: headers,
             body: body.data,
-            upgrade: upgrade
+            didUpgrade: didUpgrade
         )
     }
 
-    public init(method: Method = .get, uri: String, headers: Headers = [:], body: Data = Data(), upgrade: Upgrade? = nil) throws {
+    public init(method: Method = .get, uri: String, headers: Headers = [:], body: Data = Data(), didUpgrade: DidUpgrade? = nil) throws {
         self.init(
             method: method,
             uri: try URI(uri),
             headers: headers,
             body: body,
-            upgrade: upgrade
+            didUpgrade: didUpgrade
         )
     }
 
-    public init(method: Method = .get, uri: String, headers: Headers = [:], body: DataConvertible, upgrade: Upgrade? = nil) throws {
+    public init(method: Method = .get, uri: String, headers: Headers = [:], body: DataConvertible, didUpgrade: DidUpgrade? = nil) throws {
         try self.init(
             method: method,
             uri: uri,
             headers: headers,
             body: body.data,
-            upgrade: upgrade
+            didUpgrade: didUpgrade
         )
     }
 
-    public init(method: Method = .get, uri: String, headers: Headers = [:], body: Stream, upgrade: Upgrade? = nil) throws {
+    public init(method: Method = .get, uri: String, headers: Headers = [:], body: Stream, didUpgrade: DidUpgrade? = nil) throws {
         self.init(
             method: method,
             uri: try URI(uri),
             headers: headers,
             body: body,
-            upgrade: upgrade
+            didUpgrade: didUpgrade
         )
     }
 }

--- a/Sources/Response.swift
+++ b/Sources/Response.swift
@@ -23,46 +23,46 @@
 // SOFTWARE.
 
 extension Response {
-    public typealias Upgrade = (Request, Stream) throws -> Void
+    public typealias OnUpgrade = (Request, Stream) throws -> Void
 
-    public var upgrade: Upgrade? {
+    public var onUpgrade: OnUpgrade? {
         get {
-            return storage["response-connection-upgrade"] as? Upgrade
+            return storage["response-connection-upgrade"] as? OnUpgrade
         }
 
-        set(upgrade) {
-            storage["response-connection-upgrade"] = upgrade
+        set(onUpgrade) {
+            storage["response-connection-upgrade"] = onUpgrade
         }
     }
 }
 
 extension Response {
-    public init(status: Status = .ok, headers: Headers = [:], body: Stream, upgrade: Upgrade?) {
+    public init(status: Status = .ok, headers: Headers = [:], body: Stream, onUpgrade: OnUpgrade?) {
         self.init(
             status: status,
             headers: headers,
             body: body
         )
 
-        self.upgrade = upgrade
+        self.onUpgrade = onUpgrade
     }
 
-    public init(status: Status = .ok, headers: Headers = [:], body: Data = Data(), upgrade: Upgrade?) {
+    public init(status: Status = .ok, headers: Headers = [:], body: Data = Data(), onUpgrade: OnUpgrade?) {
         self.init(
             status: status,
             headers: headers,
             body: body
         )
 
-        self.upgrade = upgrade
+        self.onUpgrade = onUpgrade
     }
 
-    public init(status: Status = .ok, headers: Headers = [:], body: DataConvertible, upgrade: Upgrade? = nil) {
+    public init(status: Status = .ok, headers: Headers = [:], body: DataConvertible, onUpgrade: OnUpgrade? = nil) {
         self.init(
             status: status,
             headers: headers,
             body: body.data,
-            upgrade: upgrade
+            onUpgrade: onUpgrade
         )
     }
 }

--- a/Sources/Response.swift
+++ b/Sources/Response.swift
@@ -23,46 +23,46 @@
 // SOFTWARE.
 
 extension Response {
-    public typealias OnUpgrade = (Request, Stream) throws -> Void
+    public typealias DidUpgrade = (Request, Stream) throws -> Void
 
-    public var onUpgrade: OnUpgrade? {
+    public var didUpgrade: DidUpgrade? {
         get {
-            return storage["response-connection-upgrade"] as? OnUpgrade
+            return storage["response-connection-upgrade"] as? DidUpgrade
         }
 
-        set(onUpgrade) {
-            storage["response-connection-upgrade"] = onUpgrade
+        set(didUpgrade) {
+            storage["response-connection-upgrade"] = didUpgrade
         }
     }
 }
 
 extension Response {
-    public init(status: Status = .ok, headers: Headers = [:], body: Stream, onUpgrade: OnUpgrade?) {
+    public init(status: Status = .ok, headers: Headers = [:], body: Stream, didUpgrade: DidUpgrade?) {
         self.init(
             status: status,
             headers: headers,
             body: body
         )
 
-        self.onUpgrade = onUpgrade
+        self.didUpgrade = didUpgrade
     }
 
-    public init(status: Status = .ok, headers: Headers = [:], body: Data = Data(), onUpgrade: OnUpgrade?) {
+    public init(status: Status = .ok, headers: Headers = [:], body: Data = Data(), didUpgrade: DidUpgrade?) {
         self.init(
             status: status,
             headers: headers,
             body: body
         )
 
-        self.onUpgrade = onUpgrade
+        self.didUpgrade = didUpgrade
     }
 
-    public init(status: Status = .ok, headers: Headers = [:], body: DataConvertible, onUpgrade: OnUpgrade? = nil) {
+    public init(status: Status = .ok, headers: Headers = [:], body: DataConvertible, didUpgrade: DidUpgrade? = nil) {
         self.init(
             status: status,
             headers: headers,
             body: body.data,
-            onUpgrade: onUpgrade
+            didUpgrade: didUpgrade
         )
     }
 }


### PR DESCRIPTION
## Problem

Message and Request both uses “upgrade”
## Reason

S4 Defines Request is following protocol but upgrade for two different
reason.

```
public struct Request: Message {
```
## Fix

request.upgrade changes to
request.didUpgrade since this is callback function

sending all related
Zewo/HTTP
VeniceX/HTTPClient
VeniceX/HTTPSClient
VeniceX/HTTPServer
VeniceX/HTTPSServer
PR

Also Stroage[""] Parameter should be consistent
for Request use storage["request-upgrade"]
for Response use  storage["response-connection-upgrade"]
cnosistencely
