### PR TITLE
[WIP] Fixed regression on Content-Length missing

### DIFF
--- a/Sources/HTTP/Parser/MessageParser.swift
+++ b/Sources/HTTP/Parser/MessageParser.swift
@@ -92,16 +92,14 @@ public final class MessageParser {
     }
     
     public func parse(_ from: UnsafeBufferPointer<UInt8>) throws -> [Message] {
-        if !from.isEmpty {
-            let processedCount = from.baseAddress!.withMemoryRebound(to: Int8.self, capacity: from.count) {
-                return http_parser_execute(&self.parser, &self.parserSettings, $0, from.count)
-            }
-
-            guard processedCount == from.count else {
-                throw MessageParserError(parser.http_errno)
-            }
+        let processedCount = from.baseAddress!.withMemoryRebound(to: Int8.self, capacity: from.count) {
+            return http_parser_execute(&self.parser, &self.parserSettings, $0, from.count)
         }
-        
+
+        guard processedCount == from.count else {
+            throw MessageParserError(parser.http_errno)
+        }
+    
         let parsed = messages
         messages = []
         return parsed


### PR DESCRIPTION
When server doesn't set Content-Length, we should execute http_parser_execute() function with 0
as the `length` argument, to parse correctly.
